### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/brenhe/juice-shop-ada-cyb/security/code-scanning/54](https://github.com/brenhe/juice-shop-ada-cyb/security/code-scanning/54)

The correct way to fix code injection in MongoDB queries is to avoid passing user input into `$where` expressions entirely. Instead, use standard query operators that accept data as parameters rather than executable code.  
- Replace the `$where` operator with a regular query object like `{ orderId: id }`, which fully escapes user input and avoids code execution.
- Make this change in the relevant line within the `trackOrder` function in `routes/trackOrder.ts`.
- No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
